### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz_rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "pz_rail_base",
+    "pz-rail-base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "scikit-learn",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "qp-prob[full]",
 ]
 

--- a/src/rail/estimation/algos/gpz.py
+++ b/src/rail/estimation/algos/gpz.py
@@ -73,10 +73,10 @@ class GPzInformer(CatInformer):
                           replace_error_vals=Param(list, default_err_repl, msg="list of values to replace negative and nan mag err values")
                           )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization"""
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
 
     def run(self):
@@ -144,10 +144,10 @@ class GPzEstimator(CatEstimator):
                           replace_error_vals=Param(list, default_err_repl, msg="list of values to replace negative and nan mag err values")
                           )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
         # check that lengths of bands, err_bands, and replace_error_vals match
         if not np.logical_and(len(self.config.bands) == len(self.config.err_bands),

--- a/src/rail/estimation/algos/gpz.py
+++ b/src/rail/estimation/algos/gpz.py
@@ -76,7 +76,7 @@ class GPzInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
 
     def run(self):
@@ -147,7 +147,7 @@ class GPzEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
         # check that lengths of bands, err_bands, and replace_error_vals match
         if not np.logical_and(len(self.config.bands) == len(self.config.err_bands),


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.