### PR TITLE
check for inf as well as nan in mags and errors, addresses #20

### DIFF
--- a/src/rail/estimation/algos/gpz.py
+++ b/src/rail/estimation/algos/gpz.py
@@ -26,10 +26,10 @@ def _prepare_data(data_dict, bands, err_bands, nondet_val, maglims, logflag, rep
     data = np.empty([totrows, 2 * numbands])
     for i, (band, eband, lim, rplval) in enumerate(zip(bands, err_bands, maglims.values(), repl_err_vals)):
         data[:, i] = data_dict[band]
-        mask = np.bitwise_or(np.isclose(data_dict[band], nondet_val), np.isnan(data_dict[band]))
+        mask = np.bitwise_or(np.isclose(data_dict[band], nondet_val), ~np.isfinite(data_dict[band]))
         data[:, i][mask] = lim
         errband = data_dict[eband]
-        emask = np.bitwise_or(errband <= 0., np.isnan(errband))
+        emask = np.bitwise_or(errband <= 0., ~np.isfinite(errband))
         errband[emask] = rplval
         if logflag:
             data[:, numbands + i] = np.log(errband)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
addresses issue #20, simple PR that adds a check for infs as well as nans by replacing a np.isnan with ~np.isfinite in the mask definition for the preparation of data.  Stuck in some infs and it did properly catch them.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
