### PR TITLE
fix variance/sigma bug

### DIFF
--- a/src/rail/estimation/algos/gpz.py
+++ b/src/rail/estimation/algos/gpz.py
@@ -161,7 +161,7 @@ class GPzEstimator(CatEstimator):
                                    self.config.log_errors, self.config.replace_error_vals)
 
         mu, totalV, modelV, noiseV, _ = self.model.predict(test_array)
-        ens = qp.Ensemble(qp.stats.norm, data=dict(loc=mu, scale=totalV))
+        ens = qp.Ensemble(qp.stats.norm, data=dict(loc=mu, scale=np.sqrt(totalV)))
         zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
         zmode = ens.mode(grid=zgrid)
         ens.set_ancil(dict(zmode=zmode))


### PR DESCRIPTION
qp norm takes sigma, not variance


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
