### PR TITLE
Switch equality check to size check for empty array, addresses #23

### DIFF
--- a/src/rail/estimation/algos/_gpz_util.py
+++ b/src/rail/estimation/algos/_gpz_util.py
@@ -450,7 +450,9 @@ class GP:
 
         lnBeta = lnBeta+log(omega[training,:])
 
-        if Y==[]:
+        # if Y==[]:  #  NOTE: checking empty array now deprecated, switch to checking size!
+        # change made Jan 17, 2025 to fix a failure
+        if size(Y) == 0:
             return PHI,lnBeta
 
         g_dim = len(GAMMA.flatten())


### PR DESCRIPTION
Addresses #23 where a check of `if Y==[]` on L453 of _gpz_utils.py is throwing a ValueError exception, as numpy/sklearn have both deprecated boolean truth checking of an empty array.  Switching to `if size(Y) == 0:` fixes it (note that Matias has a `from numpy import *` in this file, so it's numpy.size) 

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
