### PR TITLE
change trainfrac to train_frac

### DIFF
--- a/src/rail/estimation/algos/gpz.py
+++ b/src/rail/estimation/algos/gpz.py
@@ -56,7 +56,7 @@ class GPzInformer(CatInformer):
     config_options.update(
         nondetect_val=SHARED_PARAMS,
         mag_limits=SHARED_PARAMS,
-        trainfrac=Param(
+        train_frac=Param(
             float,
             0.75,
             msg="fraction of training data used to make tree, rest used to set best sigma",
@@ -136,7 +136,7 @@ class GPzInformer(CatInformer):
         # need permutation mask to define training vs validation
         ngal = input_array.shape[0]
         print(f"ngal: {ngal}")
-        ntrain = int(ngal * self.config.trainfrac)
+        ntrain = int(ngal * self.config.train_frac)
         randvec = np.random.permutation(ngal)
         train_mask = np.zeros(ngal, dtype=bool)
         val_mask = np.zeros(ngal, dtype=bool)


### PR DESCRIPTION
Only one param rename: trainfrac -> train_frac

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
